### PR TITLE
Streams Refactor

### DIFF
--- a/src/ProtoRequest.ts
+++ b/src/ProtoRequest.ts
@@ -30,6 +30,7 @@ type CreateArgs = Parameters<typeof Protobuf.Message.create>;
 
 /**
  * Internal reason for resolving request
+ * @private
  */
 const enum ResolutionType {
   Default,
@@ -39,6 +40,7 @@ const enum ResolutionType {
 
 /**
  * Add internal options to external request params
+ * @private
  */
 interface ProtoRequestProps<RequestType, ResponseType>
   extends GenericRequestParams<RequestType, ResponseType> {
@@ -623,6 +625,7 @@ export class ProtoRequest<RequestType, ResponseType> extends EventEmitter {
 
   /**
    * Runs any middleware attached to the client
+   * @private
    */
   private async runMiddleware() {
     for (const middleware of this.client.middleware) {
@@ -889,7 +892,7 @@ export class ProtoRequest<RequestType, ResponseType> extends EventEmitter {
     if (!this.isRequestStream || !stream || this.pipeStream) {
       return;
     } else if (!this.writerSandbox) {
-      this.writeStream?.end();
+      stream.end();
       return;
     }
 
@@ -1055,6 +1058,7 @@ export class ProtoRequest<RequestType, ResponseType> extends EventEmitter {
       this.retries < this.retryOptions.retryCount &&
       code !== undefined &&
       approvedCodes.includes(code) &&
+      // Piped streams can not be retried
       !this.pipeStream
     );
   }
@@ -1070,8 +1074,8 @@ export class ProtoRequest<RequestType, ResponseType> extends EventEmitter {
 
   /**
    * Enhanced "end" event listener. Adds promise to a queue, waiting for the request
-   * to complete, rejecting on any failures. If the request is already complete, the
-   * result is returned (or exception raised)
+   * to complete, rejecting on failures only if configured to. If the request is already
+   * complete, the result is returned (or exception raised)
    * @returns {ProtoRequest} This ProtoRequest instance
    */
   public async waitForEnd(): Promise<ProtoRequest<RequestType, ResponseType>> {

--- a/src/RequestError.ts
+++ b/src/RequestError.ts
@@ -7,24 +7,30 @@ import type { UntypedProtoRequest } from "./untyped";
 export class RequestError extends Error implements ServiceError {
   /**
    * Error status code
+   * @type {status}
+   * @readonly
    */
-  public code: status;
+  public readonly code: status;
 
   /**
    * Error details
+   * @type {string}
+   * @readonly
    */
-  public details: string;
+  public readonly details: string;
 
   /**
    * Request metadata
+   * @type {Metadata}
+   * @readonly
    */
-  public metadata: Metadata;
+  public readonly metadata: Metadata;
 
   /**
    * Creates custom error for gRPC requests
-   * @param code Status code representing the error
-   * @param request ProtoRequest instance which triggered this error
-   * @param details Error details (message)
+   * @param {status} code Status code representing the error
+   * @param {ProtoRequest} request ProtoRequest instance which triggered this error
+   * @param {string} [details] Error details (message)
    */
   constructor(code: status, request: UntypedProtoRequest, details?: string) {
     if (!details) {

--- a/src/cli/FileBuilder.ts
+++ b/src/cli/FileBuilder.ts
@@ -1,10 +1,21 @@
 import { promises } from "fs";
 import color from "cli-color";
 
+export interface AddMethodsParams {
+  methodType: string;
+  namespace: string;
+  returnType: string;
+  args: Record<string, { type: string; shortType: string; desc: string }>;
+  combos: string[][];
+}
+
 /**
  * File building util used in cli
+ * @private
+ * @package
  */
 export class FileBuilder {
+  public indentCharacter = "\t";
   public filePath = "";
   public lines: string[] = [];
   public indentation: string[] = [];
@@ -28,8 +39,66 @@ export class FileBuilder {
     this.deindent();
   }
 
+  public addTypedMethods({
+    methodType,
+    namespace,
+    returnType,
+    args,
+    combos,
+  }: AddMethodsParams) {
+    const makeStrings: string[] = [];
+    const getStrings: string[] = [];
+
+    for (const combo of combos) {
+      const argDocs = combo.map((arg) => {
+        const { shortType, desc } = args[arg];
+        return ` * @param {${shortType}} ${arg} ${desc}`;
+      });
+
+      // Add doc string to make methods
+      makeStrings.push(
+        `/**`,
+        ` * ${methodType} Request to ${namespace}`,
+        ...argDocs,
+        ` */`
+      );
+
+      // Add doc string to get methods
+      getStrings.push(
+        `/**`,
+        ` * Starts ${methodType} Request to ${namespace}`,
+        ...argDocs,
+        ` */`
+      );
+
+      // Put each argument on it's own line when there are more than one
+      const argParams = combo.map((arg) => `${arg}: ${args[arg].type}`);
+      if (argParams.length > 1) {
+        makeStrings.push(`(`);
+        getStrings.push(`get(`);
+
+        argParams.forEach((row, index) => {
+          const line = `${this.indentCharacter}${row}${
+            index === argParams.length ? "" : ","
+          }`;
+
+          makeStrings.push(line);
+          getStrings.push(line);
+        });
+
+        makeStrings.push(`): Promise<${returnType}>;`);
+        getStrings.push(`): ${returnType};`);
+      } else {
+        makeStrings.push(`(${argParams}): Promise<${returnType}>;`);
+        getStrings.push(`get(${argParams}): ${returnType};`);
+      }
+    }
+
+    this.push(...makeStrings, ...getStrings);
+  }
+
   public indent() {
-    this.indentation.push(`\t`);
+    this.indentation.push(this.indentCharacter);
   }
 
   public deindent() {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -258,6 +258,7 @@ export class ProtoCli {
       const subProto = rawProto.nested[key];
 
       if (subProto.methods) {
+        // Prefill the service chain
         let serviceMethodChain = this.serviceMethodChain;
         chain.forEach((name) => {
           serviceMethodChain[name] = serviceMethodChain[name] || {
@@ -268,6 +269,7 @@ export class ProtoCli {
           serviceMethodChain = serviceMethodChain[name].nested;
         });
 
+        // Default the current service chain
         const service = serviceMethodChain[key] || {
           nested: {},
           methods: {},
@@ -275,6 +277,7 @@ export class ProtoCli {
         };
         serviceMethodChain[key] = service;
 
+        // Attach request methods
         for (const name in subProto.methods) {
           const method = subProto.methods[name];
           service.methods[name] = {
@@ -359,9 +362,7 @@ export class ProtoCli {
 
         // Attach all methods
         for (const [methodName, method] of Object.entries(subChain.methods)) {
-          const requestType = `${method.requestType}`;
-          const responseType = `${method.responseType}`;
-          const reqResType = `${requestType}, ${responseType}`;
+          const reqResType = `${method.requestType}, ${method.responseType}`;
           const returnType = `ProtoRequest<${reqResType}>`;
 
           // Open method wrapper
@@ -377,8 +378,8 @@ export class ProtoCli {
             builder.pushWithIndent(
               `/**`,
               ` * Bidirectional Request to ${method.namespace}`,
-              ` * @param {StreamWriterSandbox<${requestType}> | Readable | EventEmitter} [writerSandbox] Optional async supported callback for writing data to the open stream`,
-              ` * @param {StreamReader<${responseType}>} [streamReader] Optional iteration function that will be called on every response chunk`,
+              ` * @param {StreamWriterSandbox<${method.requestType}> | Readable | EventEmitter} [writerSandbox] Optional async supported callback for writing data to the open stream`,
+              ` * @param {StreamReader<${method.responseType}>} [streamReader] Optional iteration function that will be called on every response chunk`,
               ` * @param {AbortController | RequestOptions} [requestOptions] Optional request options for this specific request`,
               ` * @returns {Promise<${returnType}>} Request instance`,
               ` */`,
@@ -386,8 +387,8 @@ export class ProtoCli {
               `${builder.indentCharacter}protoClient.makeBidiStreamRequest("${method.namespace}", writerSandbox, streamReader, requestOptions);`,
               `/**`,
               ` * Triggers bidirectional request to ${method.namespace}, returning the ProtoRequest instance`,
-              ` * @param {StreamWriterSandbox<${requestType}> | Readable | EventEmitter} [writerSandbox] Optional async supported callback for writing data to the open stream`,
-              ` * @param {StreamReader<${responseType}>} [streamReader] Optional iteration function that will be called on every response chunk`,
+              ` * @param {StreamWriterSandbox<${method.requestType}> | Readable | EventEmitter} [writerSandbox] Optional async supported callback for writing data to the open stream`,
+              ` * @param {StreamReader<${method.responseType}>} [streamReader] Optional iteration function that will be called on every response chunk`,
               ` * @param {AbortController | RequestOptions} [requestOptions] Optional request options for this specific request`,
               ` * @returns {${returnType}} Request instance`,
               ` */`,
@@ -401,8 +402,8 @@ export class ProtoCli {
             builder.pushWithIndent(
               `/**`,
               ` * Server Stream Request to ${method.namespace}`,
-              ` * @param {${requestType} | StreamReader<${responseType}>} [data] Optional data to be sent as part of the request`,
-              ` * @param {StreamReader<${responseType}>} [streamReader] Optional iteration function that will be called on every response chunk`,
+              ` * @param {${method.requestType} | StreamReader<${method.responseType}>} [data] Optional data to be sent as part of the request`,
+              ` * @param {StreamReader<${method.responseType}>} [streamReader] Optional iteration function that will be called on every response chunk`,
               ` * @param {AbortController | RequestOptions} [requestOptions] Optional request options for this specific request`,
               ` * @returns {Promise<${returnType}>} Request instance`,
               ` */`,
@@ -410,8 +411,8 @@ export class ProtoCli {
               `${builder.indentCharacter}protoClient.makeServerStreamRequest("${method.namespace}", data, streamReader, requestOptions);`,
               `/**`,
               ` * Triggers server stream request to ${method.namespace}, returning the ProtoRequest instance`,
-              ` * @param {${requestType} | StreamReader<${responseType}>} [data] Optional data to be sent as part of the request`,
-              ` * @param {StreamReader<${responseType}>} [streamReader] Optional iteration function that will be called on every response chunk`,
+              ` * @param {${method.requestType} | StreamReader<${method.responseType}>} [data] Optional data to be sent as part of the request`,
+              ` * @param {StreamReader<${method.responseType}>} [streamReader] Optional iteration function that will be called on every response chunk`,
               ` * @param {AbortController | RequestOptions} [requestOptions] Optional request options for this specific request`,
               ` * @returns {${returnType}} Request instance`,
               ` */`,
@@ -425,7 +426,7 @@ export class ProtoCli {
             builder.pushWithIndent(
               `/**`,
               ` * Client Stream Request to ${method.namespace}`,
-              ` * @param {StreamWriterSandbox<${requestType}> | Readable | EventEmitter} [writerSandbox] Optional async supported callback for writing data to the open stream`,
+              ` * @param {StreamWriterSandbox<${method.requestType}> | Readable | EventEmitter} [writerSandbox] Optional async supported callback for writing data to the open stream`,
               ` * @param {AbortController | RequestOptions} [requestOptions] Optional request options for this specific request`,
               ` * @returns {Promise<${returnType}>} Request instance`,
               ` */`,
@@ -433,7 +434,7 @@ export class ProtoCli {
               `${builder.indentCharacter}protoClient.makeClientStreamRequest("${method.namespace}", writerSandbox, requestOptions);`,
               `/**`,
               ` * Triggers client stream request to ${method.namespace}, returning the ProtoRequest instance`,
-              ` * @param {StreamWriterSandbox<${requestType}> | Readable | EventEmitter} [writerSandbox] Optional async supported callback for writing data to the open stream`,
+              ` * @param {StreamWriterSandbox<${method.requestType}> | Readable | EventEmitter} [writerSandbox] Optional async supported callback for writing data to the open stream`,
               ` * @param {AbortController | RequestOptions} [requestOptions] Optional request options for this specific request`,
               ` * @returns {${returnType}} Request instance`,
               ` */`,
@@ -447,7 +448,7 @@ export class ProtoCli {
             builder.pushWithIndent(
               `/**`,
               ` * Unary Request to ${method.namespace}`,
-              ` * @param {${requestType} | null} [data] Optional Data to be sent as part of the request. Defaults to empty object`,
+              ` * @param {${method.requestType} | null} [data] Optional Data to be sent as part of the request. Defaults to empty object`,
               ` * @param {AbortController | RequestOptions} [requestOptions] Optional request options for this specific request`,
               ` * @returns {Promise<${returnType}>} Request instance`,
               ` */`,
@@ -455,7 +456,7 @@ export class ProtoCli {
               `${builder.indentCharacter}protoClient.makeUnaryRequest("${method.namespace}", data, requestOptions);`,
               `/**`,
               ` * Triggers unary request to ${method.namespace}, returning the ProtoRequest instance`,
-              ` * @param {${requestType} | null} [data] Optional Data to be sent as part of the request. Defaults to empty object`,
+              ` * @param {${method.requestType} | null} [data] Optional Data to be sent as part of the request. Defaults to empty object`,
               ` * @param {AbortController | RequestOptions} [requestOptions] Optional request options for this specific request`,
               ` * @returns {${returnType}} Request instance`,
               ` */`,

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -4,7 +4,7 @@ import color from "cli-color";
 import { hideBin } from "yargs/helpers";
 import { promises } from "fs";
 import { promisify } from "util";
-import { FileBuilder } from "./FileBuilder";
+import { AddMethodsParams, FileBuilder } from "./FileBuilder";
 
 interface Method {
   requestType: string;
@@ -15,10 +15,9 @@ interface Method {
 
 interface ServiceMethodChain {
   [key: string]: {
+    namespace: string;
+    methods: Record<string, Method & { namespace: string }>;
     nested: ServiceMethodChain;
-    method?: Method & {
-      namespace: string;
-    };
   };
 }
 
@@ -31,6 +30,11 @@ interface RawProtos {
   };
 }
 
+/**
+ * Cli runner to building typed endpoints for protos defined
+ * @private
+ * @package
+ */
 export class ProtoCli {
   public protoPackagePath = "proto-client";
   public protoFiles: string[] = [];
@@ -100,7 +104,7 @@ export class ProtoCli {
     process.exit(1);
   }
 
-  // Logging filename with checkmark
+  // Logging filename with check mark
   public logFileWritten(filename: string) {
     console.log(color.green(`✔ ${filename}`));
   }
@@ -251,44 +255,52 @@ export class ProtoCli {
     }
 
     for (const key in rawProto.nested) {
-      const subproto = rawProto.nested[key];
+      const subProto = rawProto.nested[key];
 
-      if (subproto.methods) {
+      if (subProto.methods) {
         let serviceMethodChain = this.serviceMethodChain;
-        [...chain, key].forEach((name) => {
-          serviceMethodChain[name] = serviceMethodChain[name] || { nested: {} };
+        chain.forEach((name) => {
+          serviceMethodChain[name] = serviceMethodChain[name] || {
+            nested: {},
+            methods: {},
+            namespace: "",
+          };
           serviceMethodChain = serviceMethodChain[name].nested;
         });
 
-        for (const name in subproto.methods) {
-          const method = subproto.methods[name];
-          serviceMethodChain[name] = {
-            method: {
-              requestType:
-                subproto.nested && subproto.nested[method.requestType]
-                  ? `${[...chain, key].join(".")}.I${method.requestType}`
-                  : `${chain.join(".")}.I${method.requestType}`,
-              responseType:
-                subproto.nested && subproto.nested[method.responseType]
-                  ? `${[...chain, key].join(".")}.I${method.responseType}`
-                  : `${chain.join(".")}.I${method.responseType}`,
-              requestStream: method.requestStream,
-              responseStream: method.responseStream,
-              namespace: [...chain, key, name].join("."),
-            },
-            nested: {},
+        const service = serviceMethodChain[key] || {
+          nested: {},
+          methods: {},
+          namespace: [...chain, key].join("."),
+        };
+        serviceMethodChain[key] = service;
+
+        for (const name in subProto.methods) {
+          const method = subProto.methods[name];
+          service.methods[name] = {
+            requestType:
+              subProto.nested && subProto.nested[method.requestType]
+                ? `${[...chain, key].join(".")}.I${method.requestType}`
+                : `${chain.join(".")}.I${method.requestType}`,
+            responseType:
+              subProto.nested && subProto.nested[method.responseType]
+                ? `${[...chain, key].join(".")}.I${method.responseType}`
+                : `${chain.join(".")}.I${method.responseType}`,
+            requestStream: method.requestStream,
+            responseStream: method.responseStream,
+            namespace: [...chain, key, name].join("."),
           };
         }
       }
 
-      this.compileServiceMethods(subproto, [...chain, key]);
+      this.compileServiceMethods(subProto, [...chain, key]);
     }
   }
 
   // Builds out client JS shortcuts
   public async writeClientJs() {
-    const fileContents = new FileBuilder(`${this.outputDirectory}/client.js`);
-    fileContents.push(
+    const builder = new FileBuilder(`${this.outputDirectory}/client.js`);
+    builder.push(
       `const { ProtoClient } = require("${this.protoPackagePath}");`,
       ``,
       `/**`,
@@ -307,109 +319,184 @@ export class ProtoCli {
       `});`
     );
 
-    for (const name in this.serviceMethodChain) {
-      fileContents.newline();
-      fileContents.push(`module.exports.${name} = {`);
-      fileContents.indent();
-      this.clientJsMethodChain(
-        this.serviceMethodChain[name].nested,
-        fileContents
+    for (const chainName in this.serviceMethodChain) {
+      builder.newline();
+      builder.push(
+        `/**`,
+        ` * ${chainName} Package`,
+        ` * @namespace ${chainName}`,
+        ` */`,
+        `module.exports.${chainName} = {`
       );
-      fileContents.deindent();
-      fileContents.push(`};`);
+      builder.indent();
+      this.clientJsMethodChain(
+        this.serviceMethodChain[chainName].nested,
+        builder
+      );
+      builder.deindent();
+      builder.push(`};`);
     }
 
-    await fileContents.write();
+    await builder.write();
   }
 
   // Nested looping to build namespaces and service methods
   public clientJsMethodChain(
     serviceChain: ServiceMethodChain,
-    fileContents: FileBuilder
+    builder: FileBuilder
   ) {
-    for (const name in serviceChain) {
-      const subchain = serviceChain[name];
+    for (const [chainName, subChain] of Object.entries(serviceChain)) {
+      // Chain entry is a service
+      if (Object.keys(subChain.methods).length) {
+        builder.push(
+          `/**`,
+          ` * ${chainName} Service`,
+          ` * @namespace ${chainName}`,
+          ` */`,
+          `${chainName}: {`
+        );
+        builder.indent();
 
-      if (subchain.method) {
-        // Bidirectional
-        if (subchain.method.requestStream && subchain.method.responseStream) {
-          fileContents.push(
+        // Attach all methods
+        for (const [methodName, method] of Object.entries(subChain.methods)) {
+          const requestType = `${method.requestType}`;
+          const responseType = `${method.responseType}`;
+          const reqResType = `${requestType}, ${responseType}`;
+          const returnType = `ProtoRequest<${reqResType}>`;
+
+          // Open method wrapper
+          builder.push(
             `/**`,
-            ` * Bidirectional Request to ${subchain.method.namespace}`,
-            ` * @param writerSandbox Async supported callback for writing data to the open stream`,
-            ` * @param streamReader Iteration function that will get called on every response chunk`,
-            ` * @param requestOptions Optional AbortController or request options for this specific request`,
+            ` * Request generation for ${methodName}`,
             ` */`,
-            `${name}: async (writerSandbox, streamReader, requestOptions) =>`
+            `${methodName}: (() => {`
           );
-          fileContents.pushWithIndent(
-            `protoClient.makeBidiStreamRequest("${subchain.method.namespace}", writerSandbox, streamReader, requestOptions),`
-          );
+
+          // Bidirectional
+          if (method.requestStream && method.responseStream) {
+            builder.pushWithIndent(
+              `/**`,
+              ` * Bidirectional Request to ${method.namespace}`,
+              ` * @param {StreamWriterSandbox<${requestType}> | Readable | EventEmitter} [writerSandbox] Optional async supported callback for writing data to the open stream`,
+              ` * @param {StreamReader<${responseType}>} [streamReader] Optional iteration function that will be called on every response chunk`,
+              ` * @param {AbortController | RequestOptions} [requestOptions] Optional request options for this specific request`,
+              ` * @returns {Promise<${returnType}>} Request instance`,
+              ` */`,
+              `const ${methodName} = async (writerSandbox, streamReader, requestOptions) =>`,
+              `${builder.indentCharacter}protoClient.makeBidiStreamRequest("${method.namespace}", writerSandbox, streamReader, requestOptions);`,
+              `/**`,
+              ` * Triggers bidirectional request to ${method.namespace}, returning the ProtoRequest instance`,
+              ` * @param {StreamWriterSandbox<${requestType}> | Readable | EventEmitter} [writerSandbox] Optional async supported callback for writing data to the open stream`,
+              ` * @param {StreamReader<${responseType}>} [streamReader] Optional iteration function that will be called on every response chunk`,
+              ` * @param {AbortController | RequestOptions} [requestOptions] Optional request options for this specific request`,
+              ` * @returns {${returnType}} Request instance`,
+              ` */`,
+              `${methodName}.get = (writerSandbox, streamReader, requestOptions) =>`,
+              `${builder.indentCharacter}protoClient.getBidiStreamRequest("${method.namespace}", writerSandbox, streamReader, requestOptions);`,
+              `return ${methodName};`
+            );
+          }
+          // Server Stream
+          else if (method.responseStream) {
+            builder.pushWithIndent(
+              `/**`,
+              ` * Server Stream Request to ${method.namespace}`,
+              ` * @param {${requestType} | StreamReader<${responseType}>} [data] Optional data to be sent as part of the request`,
+              ` * @param {StreamReader<${responseType}>} [streamReader] Optional iteration function that will be called on every response chunk`,
+              ` * @param {AbortController | RequestOptions} [requestOptions] Optional request options for this specific request`,
+              ` * @returns {Promise<${returnType}>} Request instance`,
+              ` */`,
+              `const ${methodName} = async (data, streamReader, requestOptions) =>`,
+              `${builder.indentCharacter}protoClient.makeServerStreamRequest("${method.namespace}", data, streamReader, requestOptions);`,
+              `/**`,
+              ` * Triggers server stream request to ${method.namespace}, returning the ProtoRequest instance`,
+              ` * @param {${requestType} | StreamReader<${responseType}>} [data] Optional data to be sent as part of the request`,
+              ` * @param {StreamReader<${responseType}>} [streamReader] Optional iteration function that will be called on every response chunk`,
+              ` * @param {AbortController | RequestOptions} [requestOptions] Optional request options for this specific request`,
+              ` * @returns {${returnType}} Request instance`,
+              ` */`,
+              `${methodName}.get = (data, streamReader, requestOptions) =>`,
+              `${builder.indentCharacter}protoClient.getServerStreamRequest("${method.namespace}", data, streamReader, requestOptions);`,
+              `return ${methodName};`
+            );
+          }
+          // Server Stream
+          else if (method.requestStream) {
+            builder.pushWithIndent(
+              `/**`,
+              ` * Client Stream Request to ${method.namespace}`,
+              ` * @param {StreamWriterSandbox<${requestType}> | Readable | EventEmitter} [writerSandbox] Optional async supported callback for writing data to the open stream`,
+              ` * @param {AbortController | RequestOptions} [requestOptions] Optional request options for this specific request`,
+              ` * @returns {Promise<${returnType}>} Request instance`,
+              ` */`,
+              `const ${methodName} = async (writerSandbox, requestOptions) =>`,
+              `${builder.indentCharacter}protoClient.makeClientStreamRequest("${method.namespace}", writerSandbox, requestOptions);`,
+              `/**`,
+              ` * Triggers client stream request to ${method.namespace}, returning the ProtoRequest instance`,
+              ` * @param {StreamWriterSandbox<${requestType}> | Readable | EventEmitter} [writerSandbox] Optional async supported callback for writing data to the open stream`,
+              ` * @param {AbortController | RequestOptions} [requestOptions] Optional request options for this specific request`,
+              ` * @returns {${returnType}} Request instance`,
+              ` */`,
+              `${methodName}.get = (writerSandbox, requestOptions) =>`,
+              `${builder.indentCharacter}protoClient.getClientStreamRequest("${method.namespace}", writerSandbox, requestOptions);`,
+              `return ${methodName};`
+            );
+          }
+          // Unary Request
+          else {
+            builder.pushWithIndent(
+              `/**`,
+              ` * Unary Request to ${method.namespace}`,
+              ` * @param {${requestType} | null} [data] Optional Data to be sent as part of the request. Defaults to empty object`,
+              ` * @param {AbortController | RequestOptions} [requestOptions] Optional request options for this specific request`,
+              ` * @returns {Promise<${returnType}>} Request instance`,
+              ` */`,
+              `const ${methodName} = async (data, requestOptions) =>`,
+              `${builder.indentCharacter}protoClient.makeUnaryRequest("${method.namespace}", data, requestOptions);`,
+              `/**`,
+              ` * Triggers unary request to ${method.namespace}, returning the ProtoRequest instance`,
+              ` * @param {${requestType} | null} [data] Optional Data to be sent as part of the request. Defaults to empty object`,
+              ` * @param {AbortController | RequestOptions} [requestOptions] Optional request options for this specific request`,
+              ` * @returns {${returnType}} Request instance`,
+              ` */`,
+              `${methodName}.get = (data, requestOptions) =>`,
+              `${builder.indentCharacter}protoClient.getUnaryRequest("${method.namespace}", data, requestOptions);`,
+              `return ${methodName};`
+            );
+          }
+
+          // Close out the method wrapper
+          builder.push(`})(),`);
         }
-        // Server Stream
-        else if (subchain.method.responseStream) {
-          fileContents.push(
-            `/**`,
-            ` * Server Stream Request to ${subchain.method.namespace}`,
-            ` * @param data Data to be sent as part of the request`,
-            ` * @param streamReader Iteration function that will get called on every response chunk`,
-            ` * @param requestOptions Optional AbortController or request options for this specific request`,
-            ` */`,
-            `${name}: async (data, streamReader, requestOptions) =>`
-          );
-          fileContents.pushWithIndent(
-            `protoClient.makeServerStreamRequest("${subchain.method.namespace}", data, streamReader, requestOptions),`
-          );
-        }
-        // Server Stream
-        else if (subchain.method.requestStream) {
-          fileContents.push(
-            `/**`,
-            ` * Client Stream Request to ${subchain.method.namespace}`,
-            ` * @param writerSandbox Async supported callback for writing data to the open stream`,
-            ` * @param requestOptions Optional AbortController or request options for this specific request`,
-            ` */`,
-            `${name}: async (writerSandbox, requestOptions) =>`
-          );
-          fileContents.pushWithIndent(
-            `protoClient.makeClientStreamRequest("${subchain.method.namespace}", writerSandbox, requestOptions),`
-          );
-        }
-        // Unary Request
-        else {
-          fileContents.push(
-            `/**`,
-            ` * Unary Request to ${subchain.method.namespace}`,
-            ` * @param data Data to be sent as part of the request`,
-            ` * @param requestOptions Optional AbortController or request options for this specific request`,
-            ` */`,
-            `${name}: async (data, requestOptions) =>`
-          );
-          fileContents.pushWithIndent(
-            `protoClient.makeUnaryRequest("${subchain.method.namespace}", data, requestOptions),`
-          );
-        }
+
+        // Close out service
+        builder.deindent();
+        builder.push(`},`);
       }
-    }
-
-    for (const name in serviceChain) {
-      if (Object.keys(serviceChain[name].nested).length) {
-        fileContents.newline();
-        fileContents.push(`${name}: {`);
-        fileContents.indent();
-        this.clientJsMethodChain(serviceChain[name].nested, fileContents);
-        fileContents.deindent();
-        fileContents.push(`},`);
+      // Keep digging
+      else if (Object.keys(subChain.nested).length) {
+        builder.push(
+          `/**`,
+          ` * ${chainName} Package`,
+          ` * @namespace ${chainName}`,
+          ` */`,
+          `${chainName}: {`
+        );
+        builder.indent();
+        this.clientJsMethodChain(subChain.nested, builder);
+        builder.deindent();
+        builder.push(`},`);
       }
     }
   }
 
   // Writing types for client shortcuts
   public async writeClientTypes() {
-    const fileContents = new FileBuilder(`${this.outputDirectory}/client.d.ts`);
+    const builder = new FileBuilder(`${this.outputDirectory}/client.d.ts`);
 
-    fileContents.push(
+    builder.push(
       `import { ProtoClient, ProtoRequest, RequestOptions, StreamWriterSandbox, StreamReader } from "${this.protoPackagePath}";`,
+      `import { Readable , EventEmitter } from "stream";`,
       `import protos from "./protos";`,
       ``,
       `/**`,
@@ -418,172 +505,185 @@ export class ProtoCli {
       `export const protoClient: ProtoClient;`
     );
 
-    for (const name in this.serviceMethodChain) {
-      fileContents.newline();
-      fileContents.push(
-        `/** Namespace ${name} */`,
-        `export namespace ${name} {`
+    for (const chainName in this.serviceMethodChain) {
+      builder.newline();
+      builder.push(
+        `/**`,
+        ` * ${chainName} Package`,
+        ` * @namespace ${chainName}`,
+        ` */`,
+        `export namespace ${chainName} {`
       );
-      fileContents.indent();
+      builder.indent();
       this.clientTypesMethodChain(
-        this.serviceMethodChain[name].nested,
-        fileContents
+        this.serviceMethodChain[chainName].nested,
+        builder
       );
-      fileContents.deindent();
-      fileContents.push(`}`);
+      builder.deindent();
+      builder.push(`}`);
     }
 
-    await fileContents.write();
+    await builder.write();
   }
 
   // Builds nested namespaces and service method typings
   public clientTypesMethodChain(
     serviceChain: ServiceMethodChain,
-    fileContents: FileBuilder
+    builder: FileBuilder
   ) {
-    for (const name in serviceChain) {
-      const subchain = serviceChain[name];
+    for (const [chainName, subChain] of Object.entries(serviceChain)) {
+      // Chain entry is a service
+      if (Object.keys(subChain.methods).length) {
+        builder.push(
+          `/**`,
+          ` * ${chainName} Service`,
+          ` * @namespace ${chainName}`,
+          ` */`,
+          `namespace ${chainName} {`
+        );
+        builder.indent();
 
-      if (subchain.method) {
-        const requestType = `protos.${subchain.method.requestType}`;
-        const responseType = `protos.${subchain.method.responseType}`;
-        const reqResType = `${requestType}, ${responseType}`;
-        const returnType = `Promise<ProtoRequest<${reqResType}>>`;
+        // Attach all methods
+        for (const [methodName, method] of Object.entries(subChain.methods)) {
+          const requestType = `protos.${method.requestType}`;
+          const responseType = `protos.${method.responseType}`;
+          const reqResType = `${requestType}, ${responseType}`;
+          const returnType = `ProtoRequest<${reqResType}>`;
 
-        // Bidirectional
-        if (subchain.method.requestStream && subchain.method.responseStream) {
-          fileContents.push(
+          const args: AddMethodsParams["args"] = {
+            data: {
+              type: `${requestType} | null`,
+              shortType: `${requestType} | null`,
+              desc: `Data to be sent as part of the request`,
+            },
+            writerSandbox: {
+              type: `StreamWriterSandbox<${reqResType}>`,
+              shortType: `StreamWriterSandbox`,
+              desc: `Async supported callback for writing data to the open stream`,
+            },
+            stream: {
+              type: `Readable | EventEmitter`,
+              shortType: `Readable | EventEmitter`,
+              desc: `Readable like stream for piping into the request stream`,
+            },
+            streamReader: {
+              type: `StreamReader<${reqResType}>`,
+              shortType: `StreamReader`,
+              desc: `Iteration function that will be called on every response chunk`,
+            },
+            abortController: {
+              type: `AbortController`,
+              shortType: `AbortController`,
+              desc: `Data to be sent as part of the request`,
+            },
+            requestOptions: {
+              type: `RequestOptions`,
+              shortType: `RequestOptions`,
+              desc: `Request options for this specific request`,
+            },
+          };
+
+          builder.push(
             `/**`,
-            ` * Bidirectional Request to ${subchain.method.namespace}`,
-            ` * @param writerSandbox Async supported callback for writing data to the open stream`,
-            ` * @param streamReader Iteration function that will get called on every response chunk`,
+            ` * Request generation for ${method.namespace}`,
             ` */`,
-            `function ${name}(writerSandbox: StreamWriterSandbox<${reqResType}>, streamReader: StreamReader<${reqResType}>): ${returnType}`
+            `const ${methodName}: {`
           );
-          fileContents.push(
-            `/**`,
-            ` * Bidirectional Request to ${subchain.method.namespace}`,
-            ` * @param writerSandbox Async supported callback for writing data to the open stream`,
-            ` * @param streamReader Iteration function that will get called on every response chunk`,
-            ` * @param abortController Abort controller for canceling the active request`,
-            ` */`,
-            `function ${name}(writerSandbox: StreamWriterSandbox<${reqResType}>, streamReader: StreamReader<${reqResType}>, abortController: AbortController): ${returnType}`
-          );
-          fileContents.push(
-            `/**`,
-            ` * Bidirectional Request to ${subchain.method.namespace}`,
-            ` * @param writerSandbox Async supported callback for writing data to the open stream`,
-            ` * @param streamReader Iteration function that will get called on every response chunk`,
-            ` * @param requestOptions Request options for this specific request`,
-            ` */`,
-            `function ${name}(writerSandbox: StreamWriterSandbox<${reqResType}>, streamReader: StreamReader<${reqResType}>, requestOptions: RequestOptions): ${returnType}`
-          );
+          builder.indent();
+
+          // Bidirectional
+          if (method.requestStream && method.responseStream) {
+            builder.addTypedMethods({
+              methodType: `Bidirectional Stream`,
+              namespace: method.namespace,
+              returnType,
+              args,
+              combos: [
+                [],
+                ["writerSandbox"],
+                ["writerSandbox", "streamReader"],
+                ["writerSandbox", "streamReader", "abortController"],
+                ["writerSandbox", "streamReader", "requestOptions"],
+                ["stream"],
+                ["stream", "streamReader"],
+                ["stream", "streamReader", "abortController"],
+                ["stream", "streamReader", "requestOptions"],
+              ],
+            });
+          }
+          // Server Stream
+          else if (method.responseStream) {
+            builder.addTypedMethods({
+              methodType: `Server Stream`,
+              namespace: method.namespace,
+              returnType,
+              args,
+              combos: [
+                [],
+                ["streamReader"],
+                ["data"],
+                ["data", "streamReader"],
+                ["data", "streamReader", "abortController"],
+                ["data", "streamReader", "requestOptions"],
+              ],
+            });
+          }
+          // Server Stream
+          else if (method.requestStream) {
+            builder.addTypedMethods({
+              methodType: `Client Stream`,
+              namespace: method.namespace,
+              returnType,
+              args,
+              combos: [
+                [],
+                ["writerSandbox"],
+                ["writerSandbox", "abortController"],
+                ["writerSandbox", "requestOptions"],
+                ["stream"],
+                ["stream", "abortController"],
+                ["stream", "requestOptions"],
+              ],
+            });
+          }
+          // Unary Request
+          else {
+            builder.addTypedMethods({
+              methodType: `Unary`,
+              namespace: method.namespace,
+              returnType,
+              args,
+              combos: [
+                [],
+                ["data"],
+                ["data", "abortController"],
+                ["data", "requestOptions"],
+              ],
+            });
+          }
+
+          // Close of method interface
+          builder.deindent();
+          builder.push(`}`);
         }
-        // Server Stream
-        else if (subchain.method.responseStream) {
-          fileContents.push(
-            `/**`,
-            ` * Server Stream Request to ${subchain.method.namespace}`,
-            ` * @param streamReader Iteration function that will get called on every response chunk`,
-            ` */`,
-            `function ${name}(streamReader: StreamReader<${reqResType}>): ${returnType}`
-          );
-          fileContents.push(
-            `/**`,
-            ` * Server Stream Request to ${subchain.method.namespace}`,
-            ` * @param data Data to be sent as part of the request`,
-            ` * @param streamReader Iteration function that will get called on every response chunk`,
-            ` */`,
-            `function ${name}(data: ${requestType}, streamReader: StreamReader<${reqResType}>): ${returnType}`
-          );
-          fileContents.push(
-            `/**`,
-            ` * Server Stream Request to ${subchain.method.namespace}`,
-            ` * @param data Data to be sent as part of the request`,
-            ` * @param streamReader Iteration function that will get called on every response chunk`,
-            ` * @param abortController Abort controller for canceling the active request`,
-            ` */`,
-            `function ${name}(data: ${requestType}, streamReader: StreamReader<${reqResType}>, abortController: AbortController): ${returnType}`
-          );
-          fileContents.push(
-            `/**`,
-            ` * Server Stream Request to ${subchain.method.namespace}`,
-            ` * @param data Data to be sent as part of the request`,
-            ` * @param streamReader Iteration function that will get called on every response chunk`,
-            ` * @param requestOptions Request options for this specific request`,
-            ` */`,
-            `function ${name}(data: ${requestType}, streamReader: StreamReader<${reqResType}>, requestOptions: RequestOptions): ${returnType}`
-          );
-        }
-        // Server Stream
-        else if (subchain.method.requestStream) {
-          fileContents.push(
-            `/**`,
-            ` * Client Stream Request to ${subchain.method.namespace}`,
-            ` * @param writerSandbox Async supported callback for writing data to the open stream`,
-            ` */`,
-            `function ${name}(writerSandbox: StreamWriterSandbox<${reqResType}>): ${returnType}`
-          );
-          fileContents.push(
-            `/**`,
-            ` * Client Stream Request to ${subchain.method.namespace}`,
-            ` * @param writerSandbox Async supported callback for writing data to the open stream`,
-            ` * @param abortController Abort controller for canceling the active request`,
-            ` */`,
-            `function ${name}(writerSandbox: StreamWriterSandbox<${reqResType}>, abortController: AbortController): ${returnType}`
-          );
-          fileContents.push(
-            `/**`,
-            ` * Client Stream Request to ${subchain.method.namespace}`,
-            ` * @param writerSandbox Async supported callback for writing data to the open stream`,
-            ` * @param requestOptions Request options for this specific request`,
-            ` */`,
-            `function ${name}(writerSandbox: StreamWriterSandbox<${reqResType}>, requestOptions: RequestOptions): ${returnType}`
-          );
-        }
-        // Unary Request
-        else {
-          fileContents.push(
-            `/**`,
-            ` * Unary Request to ${subchain.method.namespace}`,
-            ` */`,
-            `function ${name}(): ${returnType}`
-          );
-          fileContents.push(
-            `/**`,
-            ` * Unary Request to ${subchain.method.namespace}`,
-            ` * @param data Data to be sent as part of the request`,
-            ` */`,
-            `function ${name}(data: ${requestType}): ${returnType}`
-          );
-          fileContents.push(
-            `/**`,
-            ` * Unary Request to ${subchain.method.namespace}`,
-            ` * @param data Data to be sent as part of the request. Defaults to empty object`,
-            ` * @param abortController Abort controller for canceling the active request`,
-            ` */`,
-            `function ${name}(data: ${requestType} | null, abortController: AbortController): ${returnType}`
-          );
-          fileContents.push(
-            `/**`,
-            ` * Unary Request to ${subchain.method.namespace}`,
-            ` * @param data Data to be sent as part of the request. Defaults to empty object`,
-            ` * @param requestOptions Request options for this specific request`,
-            ` */`,
-            `function ${name}(data: ${requestType} | null, requestOptions: RequestOptions): ${returnType}`
-          );
-        }
+
+        // Close off service
+        builder.deindent();
+        builder.push(`}`);
       }
-    }
-
-    for (const name in serviceChain) {
-      if (Object.keys(serviceChain[name].nested).length) {
-        fileContents.newline();
-        fileContents.push(`namespace ${name} {`);
-        fileContents.indent();
-        this.clientTypesMethodChain(serviceChain[name].nested, fileContents);
-        fileContents.deindent();
-        fileContents.push(`}`);
+      // Keep digging
+      else if (Object.keys(subChain.nested).length) {
+        builder.push(
+          `/**`,
+          ` * ${chainName} Package`,
+          ` * @namespace ${chainName}`,
+          ` */`,
+          `namespace ${chainName} {`
+        );
+        builder.indent();
+        this.clientTypesMethodChain(subChain.nested, builder);
+        builder.deindent();
+        builder.push(`}`);
       }
     }
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,8 +2,10 @@ import { status } from "@grpc/grpc-js";
 
 /**
  * Supported gRPC request types
+ * @enum {string}
+ * @readonly
  */
-export const enum RequestMethodType {
+export enum RequestMethodType {
   UnaryRequest = "makeUnaryRequest",
   ClientStreamRequest = "makeClientStreamRequest",
   ServerStreamRequest = "makeServerStreamRequest",
@@ -12,6 +14,7 @@ export const enum RequestMethodType {
 
 /**
  * Default list of status that can be retried
+ * @type {status[]}
  */
 export const DEFAULT_RETRY_STATUS_CODES: status[] = [
   status.CANCELLED,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import type { ProtoRequest } from "./ProtoRequest";
+import { ProtoRequest } from "./ProtoRequest";
 import type * as Protobuf from "protobufjs";
 import type { UntypedProtoRequest } from "./untyped";
 import type { ProtoClient } from "./ProtoClient";
@@ -11,6 +11,8 @@ import type {
   status,
 } from "@grpc/grpc-js";
 import type { VerifyOptions } from "@grpc/grpc-js/build/src/channel-credentials";
+import type { RequestMethodType } from "./constants";
+import type { EventEmitter, Readable } from "stream";
 
 /**
  * Method filter function
@@ -89,9 +91,14 @@ export interface ClientSettings {
   endpoint: string | ClientEndpoint | ClientEndpoint[];
 
   /**
-   * Indicates if error should be thrown when caller cancels the request
+   * Indicates if request/response errors should be thrown. Defaults to false
    */
-  rejectOnAbort?: true;
+  rejectOnError?: boolean;
+
+  /**
+   * Indicates if error should be thrown when caller cancels the request. Defaults to false
+   */
+  rejectOnAbort?: boolean;
 
   /**
    * Time in milliseconds before cancelling the request. Defaults to 0 for no timeout
@@ -212,4 +219,38 @@ export interface RequestOptions {
    * @alias RequestRetryOptions Custom retry options
    */
   retryOptions?: boolean | number | RequestRetryOptions;
+}
+
+/**
+ * Parameters for generating any proto request
+ */
+export interface GenericRequestParams<RequestType, ResponseType> {
+  /**
+   * Fully qualified path of the method for the request that can be used by protobufjs.lookup
+   */
+  method: string;
+  /**
+   * Type of method for the request
+   */
+  requestMethodType?: RequestMethodType;
+  /**
+   * Data to be sent for unary requests
+   */
+  data?: RequestType;
+  /**
+   * Pipes data from a stream to the request stream
+   */
+  pipeStream?: EventEmitter | Readable;
+  /**
+   * Write sandbox for sending data on request streams
+   */
+  writerSandbox?: StreamWriterSandbox<RequestType, ResponseType>;
+  /**
+   * Read iterator for listening on response streams
+   */
+  streamReader?: StreamReader<RequestType, ResponseType>;
+  /**
+   * Request specific options
+   */
+  requestOptions?: RequestOptions;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,8 +6,10 @@ import type {
 
 /**
  * Generates a function for matching namespaces to requests
- * @param match Multi-type endpoint matcher to convert
+ * @param {string | RegExp | EndpointMatcher} match Multi-type endpoint matcher to convert
  * @returns Matcher function
+ * @private
+ * @package
  */
 export const generateEndpointMatcher = (
   match?: string | RegExp | EndpointMatcher
@@ -30,7 +32,10 @@ export const generateEndpointMatcher = (
 
 /**
  * Normalizes provided retry options into configuration object
- * @param options Various retry option types
+ * @param {boolean | number | RequestRetryOptions} options Various retry option types
+ * @returns {RequestRetryOptions | undefined} Normalized retry options if they are passed in
+ * @private
+ * @package
  */
 export const normalizeRetryOptions = (
   options: RequestOptions["retryOptions"]

--- a/test/Cli.test.ts
+++ b/test/Cli.test.ts
@@ -24,7 +24,7 @@ describe("Cli", () => {
       `--keep-case`,
       ...PROTO_FILE_PATHS,
     ]);
-    cli.protoPackagePath = `${__dirname}/../src`;
+    cli.protoPackagePath = `../../src`;
     await cli.run();
   });
 

--- a/test/ProtoClient.test.ts
+++ b/test/ProtoClient.test.ts
@@ -92,12 +92,12 @@ describe("ProtoClient", () => {
     const results = await startServer(serviceMethods);
     client = results.client;
 
-    request = new ProtoRequest<GetCustomerRequest, Customer>(
+    request = new ProtoRequest<GetCustomerRequest, Customer>({
       client,
-      "customers.Customers.GetCustomer",
-      RequestMethodType.UnaryRequest,
-      undefined
-    );
+      method: "customers.Customers.GetCustomer",
+      requestMethodType: RequestMethodType.UnaryRequest,
+      blockAutoStart: true,
+    });
   });
 
   test("should proxy settings passed on init to each configuration method", () => {

--- a/test/ProtoRequest.test.ts
+++ b/test/ProtoRequest.test.ts
@@ -1,39 +1,106 @@
-import { ServerUnaryCall, sendUnaryData } from "@grpc/grpc-js";
+import { ServerUnaryCall, sendUnaryData, status } from "@grpc/grpc-js";
 import {
   startServer,
   GetCustomerRequest,
   Customer,
-  makeUnaryRequest,
   getClient,
+  getUnaryRequest,
+  wait,
+  makeUnaryRequest,
 } from "./utils";
+import { MockServiceError } from "./MockServiceError";
+import { ProtoClient, ProtoRequest } from "../src";
 
 describe("ProtoRequest", () => {
+  let client: ProtoClient;
+  let RESPONSE_DELAY: number;
+  let THROW_ERROR: MockServiceError | undefined;
+  let methodTimerId: NodeJS.Timeout | undefined;
+
   beforeEach(async () => {
+    RESPONSE_DELAY = 0;
+    THROW_ERROR = undefined;
+    methodTimerId = undefined;
+
     await startServer({
       GetCustomer: (
         _call: ServerUnaryCall<GetCustomerRequest, Customer>,
         callback: sendUnaryData<Customer>
       ) => {
-        callback(null, { id: "github", name: "Github" });
+        methodTimerId = setTimeout(() => {
+          methodTimerId = undefined;
+          if (THROW_ERROR) {
+            callback(THROW_ERROR);
+          } else {
+            callback(null, { id: "github", name: "Github" });
+          }
+        }, RESPONSE_DELAY);
       },
     });
+
+    client = getClient();
+  });
+
+  afterEach(() => {
+    if (methodTimerId) {
+      clearTimeout(methodTimerId);
+    }
+  });
+
+  test("should queue up multiple run requests", async () => {
+    const request = getUnaryRequest();
+
+    const results = await Promise.all([
+      request.waitForEnd(),
+      request.waitForEnd(),
+      request.waitForEnd(),
+    ]);
+
+    expect(results.map((req) => req.result)).toEqual([
+      { id: "github", name: "Github" },
+      { id: "github", name: "Github" },
+      { id: "github", name: "Github" },
+    ]);
+
+    // Triggering run again should return the current request
+    expect(await request.waitForEnd()).toStrictEqual(request);
+  });
+
+  test("should rethrow errors when running the same request", async () => {
+    THROW_ERROR = new MockServiceError(
+      status.INTERNAL,
+      "Generic Service Error"
+    );
+
+    client.clientSettings.rejectOnError = true;
+    const request = getUnaryRequest();
+
+    // Wait for initial response to return
+    await expect(request.waitForEnd()).rejects.toThrow(
+      `${status.INTERNAL} INTERNAL: Generic Service Error`
+    );
+
+    // Running the same request should throw again
+    await expect(request.waitForEnd()).rejects.toThrow(
+      `${status.INTERNAL} INTERNAL: Generic Service Error`
+    );
   });
 
   test("should throw an error when attempting to request from a service that does not exist", async () => {
     await expect(
-      getClient().makeUnaryRequest("foo.bar.not.here", {})
+      client.makeUnaryRequest("foo.bar.not.here", {})
     ).rejects.toThrow(`no such Service 'foo.bar.not' in Root`);
   });
 
   test("should throw an error when attempting to request from a method that does not exist on the service", async () => {
     await expect(
-      getClient().makeUnaryRequest("customers.Customers.NotHere", {})
+      client.makeUnaryRequest("customers.Customers.NotHere", {})
     ).rejects.toThrow(`Method NotHere not found on customers.Customers`);
   });
 
   test("should throw an error if attempting to request a method with an incorrect type", async () => {
     await expect(
-      getClient().makeServerStreamRequest(
+      client.makeServerStreamRequest(
         "customers.Customers.GetCustomer",
         async () => undefined
       )
@@ -42,11 +109,164 @@ describe("ProtoRequest", () => {
     );
   });
 
-  test("should lock request instance so that it can only run once", async () => {
-    const request = await makeUnaryRequest();
+  describe("Queued Errors", () => {
+    let request: ProtoRequest<GetCustomerRequest, Customer>;
 
-    await expect(request.makeUnaryRequest()).rejects.toThrow(
-      `makeUnaryRequest for 'customers.Customers.GetCustomer' has already begun. Only make requests from the client, not the request instance`
-    );
+    beforeEach(async () => {
+      THROW_ERROR = new MockServiceError(
+        status.INTERNAL,
+        "Mock Internal Error"
+      );
+      RESPONSE_DELAY = 100;
+      request = getUnaryRequest();
+      await wait(25);
+    });
+
+    test("should resolve without throwing by default", async () => {
+      await request.waitForEnd();
+      expect(request.error?.message).toStrictEqual(
+        `13 INTERNAL: Mock Internal Error`
+      );
+    });
+
+    test("should resolve without throwing when rejectOnError is disabled", async () => {
+      client.clientSettings.rejectOnError = false;
+      await request.waitForEnd();
+      expect(request.error?.message).toStrictEqual(
+        `13 INTERNAL: Mock Internal Error`
+      );
+    });
+
+    test("should throw error when rejectOnError is enabled", async () => {
+      client.clientSettings.rejectOnError = true;
+      await expect(request.waitForEnd()).rejects.toThrow(
+        `13 INTERNAL: Mock Internal Error`
+      );
+    });
+
+    test("should not resolve when rejectOnAbort is not enabled", async () => {
+      return new Promise<void>((resolve, reject) => {
+        request
+          .waitForEnd()
+          .then(() =>
+            reject("should not resolve when rejectOnAbort is disabled")
+          )
+          .catch(() =>
+            reject("should not resolve when rejectOnAbort is disabled")
+          );
+
+        request.on("aborted", () => {
+          setTimeout(() => resolve(), 50);
+        });
+        request.abortController.abort();
+      });
+    });
+
+    test("should throw error when rejectOnAbort is enabled", async () => {
+      client.clientSettings.rejectOnAbort = true;
+
+      return new Promise<void>((resolve, reject) => {
+        request
+          .waitForEnd()
+          .then(() =>
+            reject("should not resolve when rejectOnAbort is enabled")
+          )
+          .catch((e) => {
+            try {
+              expect(e).toBeInstanceOf(Error);
+              expect((e as Error).message).toStrictEqual(
+                `Cancelled makeUnaryRequest for 'customers.Customers.GetCustomer'`
+              );
+              resolve();
+            } catch (testError) {
+              reject(testError);
+            }
+          });
+
+        request.on("aborted", () => {
+          setTimeout(
+            () =>
+              reject(
+                `should have already resolved by the time aborted event is called`
+              ),
+            50
+          );
+        });
+        request.abortController.abort();
+      });
+    });
+  });
+
+  describe("Resolved Errors", () => {
+    let request: ProtoRequest<GetCustomerRequest, Customer>;
+
+    beforeEach(async () => {
+      THROW_ERROR = new MockServiceError(
+        status.INTERNAL,
+        "Mock Internal Error"
+      );
+      request = await makeUnaryRequest();
+    });
+
+    test("should return immediately without throwing by default", async () => {
+      await request.waitForEnd();
+      expect(request.error?.message).toStrictEqual(
+        `13 INTERNAL: Mock Internal Error`
+      );
+    });
+
+    test("should return immediately without throwing when rejectOnError is disabled", async () => {
+      client.clientSettings.rejectOnError = false;
+      await request.waitForEnd();
+      expect(request.error?.message).toStrictEqual(
+        `13 INTERNAL: Mock Internal Error`
+      );
+    });
+
+    test("should throw error immediately when rejectOnError is enabled", async () => {
+      client.clientSettings.rejectOnError = true;
+      await expect(request.waitForEnd()).rejects.toThrow(
+        `13 INTERNAL: Mock Internal Error`
+      );
+    });
+
+    test("should not return when rejectOnAbort is not enabled", async () => {
+      RESPONSE_DELAY = 100;
+      request = getUnaryRequest();
+      await wait(50);
+      request.abortController.abort();
+      return new Promise<void>((resolve, reject) => {
+        request
+          .waitForEnd()
+          .then(() =>
+            reject("should not resolve when rejectOnAbort is disabled")
+          )
+          .catch(() =>
+            reject("should not resolve when rejectOnAbort is disabled")
+          );
+
+        setTimeout(() => {
+          if (request.isActive) {
+            reject("request is still active, can not confirm abort worked");
+          } else {
+            resolve();
+          }
+        }, 75);
+      });
+    });
+
+    test("should throw error immediately when rejectOnAbort is enabled", async () => {
+      client.clientSettings.rejectOnAbort = true;
+      RESPONSE_DELAY = 100;
+      request = getUnaryRequest();
+      await wait(50);
+      request.abortController.abort();
+      await wait(25);
+
+      expect(request.isActive).toStrictEqual(false);
+      await expect(request.waitForEnd()).rejects.toThrow(
+        `Cancelled makeUnaryRequest for 'customers.Customers.GetCustomer'`
+      );
+    });
   });
 });

--- a/test/RequestError.test.ts
+++ b/test/RequestError.test.ts
@@ -20,12 +20,12 @@ describe("RequestError", () => {
       },
     });
 
-    request = new ProtoRequest<GetCustomerRequest, Customer>(
+    request = new ProtoRequest<GetCustomerRequest, Customer>({
       client,
-      "customers.Customers.GetCustomer",
-      RequestMethodType.UnaryRequest,
-      undefined
-    );
+      method: "customers.Customers.GetCustomer",
+      requestMethodType: RequestMethodType.UnaryRequest,
+      blockAutoStart: true,
+    });
   });
 
   test("should assign parameters and auto set code to aborted", () => {

--- a/test/makeRequest.test.ts
+++ b/test/makeRequest.test.ts
@@ -1,0 +1,78 @@
+import {
+  ServerUnaryCall,
+  sendUnaryData,
+  ServerDuplexStream,
+} from "@grpc/grpc-js";
+import { ProtoClient, RequestMethodType } from "../src";
+import {
+  Customer,
+  FindCustomersRequest,
+  getClient,
+  GetCustomerRequest,
+  startServer,
+} from "./utils";
+
+describe("makeRequest", () => {
+  let client: ProtoClient;
+
+  beforeEach(async () => {
+    await startServer({
+      GetCustomer: (
+        _call: ServerUnaryCall<GetCustomerRequest, Customer>,
+        callback: sendUnaryData<Customer>
+      ) => {
+        callback(null, { id: "github", name: "Github" });
+      },
+
+      CreateCustomers: (call: ServerDuplexStream<Customer, Customer>) => {
+        call.on("data", (row) => {
+          call.write(row);
+        });
+
+        call.on("end", () => {
+          call.end();
+        });
+      },
+    });
+
+    client = getClient();
+  });
+
+  test("should be able to make a request by method only", async () => {
+    const { result } = await client.makeRequest<FindCustomersRequest, Customer>(
+      "customers.Customers.GetCustomer"
+    );
+
+    expect(result).toStrictEqual({ id: "github", name: "Github" });
+  });
+
+  test("should be able to make a request by params only", async () => {
+    const customers: Customer[] = [];
+    await client.makeRequest<Customer, Customer>({
+      method: "customers.Customers.CreateCustomers",
+      writerSandbox: async (write) => {
+        await write({ id: "github", name: "Github" });
+        await write({ id: "npm", name: "NPM" });
+      },
+      streamReader: async (row) => {
+        customers.push(row);
+      },
+    });
+
+    expect(customers).toEqual([
+      { id: "github", name: "Github" },
+      { id: "npm", name: "NPM" },
+    ]);
+  });
+
+  test("should only throw an error if attempting to safe guard method type", async () => {
+    await expect(
+      client.makeRequest({
+        method: "customers.Customers.GetCustomer",
+        requestMethodType: RequestMethodType.BidiStreamRequest,
+      })
+    ).rejects.toThrow(
+      `makeBidiStreamRequest does not support method 'customers.Customers.GetCustomer', use makeUnaryRequest instead`
+    );
+  });
+});

--- a/test/makeServerStreamRequest.test.ts
+++ b/test/makeServerStreamRequest.test.ts
@@ -1,10 +1,10 @@
 import { ServerWritableStream, status } from "@grpc/grpc-js";
-import { RequestError, ProtoRequest } from "../src";
 import { promisify } from "util";
 import {
   Customer,
   FindCustomersRequest,
   getClient,
+  getServerStreamRequest,
   makeServerStreamRequest,
   startServer,
   wait,
@@ -15,7 +15,6 @@ describe("makeServerStreamRequest", () => {
   let RESPONSE_DELAY: number;
   let THROW_ERROR_RESPONSE: boolean;
   let TOGGLE_THROWN_ERROR: boolean;
-  let activeRequest: ProtoRequest<FindCustomersRequest, Customer>;
 
   beforeEach(async () => {
     THROW_ERROR_RESPONSE = false;
@@ -33,7 +32,7 @@ describe("makeServerStreamRequest", () => {
       (customer) => (CUSTOMERS_HASH[customer.id as string] = customer)
     );
 
-    const { client } = await startServer({
+    await startServer({
       FindCustomers: (
         call: ServerWritableStream<FindCustomersRequest, Customer>
       ) => {
@@ -60,10 +59,6 @@ describe("makeServerStreamRequest", () => {
           }
         });
       },
-    });
-
-    client.useMiddleware(async (req) => {
-      activeRequest = req;
     });
   });
 
@@ -123,6 +118,33 @@ describe("makeServerStreamRequest", () => {
     ]);
   });
 
+  test("should support not passing a stream reader", async () => {
+    const customers: Customer[] = [];
+
+    const request = getClient().getServerStreamRequest<Customer>(
+      "customers.Customers.FindCustomers"
+    );
+    request.on("data", (row) => {
+      customers.push(row);
+    });
+    await request.waitForEnd();
+
+    expect(customers).toEqual([
+      {
+        id: "github",
+        name: "Github",
+      },
+      {
+        id: "npm",
+        name: "NPM",
+      },
+      {
+        id: "jira",
+        name: "JIRA",
+      },
+    ]);
+  });
+
   test("should wait for all read processing to complete before resolving promise", async () => {
     const customers: Customer[] = [];
 
@@ -149,111 +171,102 @@ describe("makeServerStreamRequest", () => {
 
   test("should ignore first try failure if the retry is successful", async () => {
     RESPONSE_DELAY = 1000;
-    return new Promise<void>((resolve, reject) => {
-      const customers: Customer[] = [];
-
-      makeServerStreamRequest(
-        {},
-        async (row) => {
-          customers.push(row);
-        },
-        { timeout: 200, retryOptions: true }
-      )
-        .then((request) => {
-          try {
-            expect(customers).toEqual([
-              {
-                id: "github",
-                name: "Github",
-              },
-              {
-                id: "npm",
-                name: "NPM",
-              },
-              {
-                id: "jira",
-                name: "JIRA",
-              },
-            ]);
-            expect(request.error).toBeUndefined();
-            expect(request.responseErrors).toEqual([
-              expect.objectContaining({ code: status.DEADLINE_EXCEEDED }),
-            ]);
-            resolve();
-          } catch (e) {
-            reject(e);
-          }
-        })
-        .catch((e) => {
-          reject(e);
-        });
-
-      setTimeout(() => (RESPONSE_DELAY = 0), 100);
-    });
-  });
-
-  test("should throw when missing streamReader", async () => {
-    await expect(makeServerStreamRequest({ name: "github" })).rejects.toThrow(
-      `streamReader not found`
+    const customers: Customer[] = [];
+    const request = getServerStreamRequest(
+      {},
+      async (row) => {
+        customers.push(row);
+      },
+      { timeout: 200, retryOptions: true }
     );
+
+    await wait(100);
+    RESPONSE_DELAY = 0;
+
+    await request.waitForEnd();
+    expect(customers).toEqual([
+      {
+        id: "github",
+        name: "Github",
+      },
+      {
+        id: "npm",
+        name: "NPM",
+      },
+      {
+        id: "jira",
+        name: "JIRA",
+      },
+    ]);
+    expect(request.error).toBeUndefined();
+    expect(request.responseErrors).toEqual([
+      expect.objectContaining({ code: status.DEADLINE_EXCEEDED }),
+    ]);
   });
 
   test("should propagate validation errors", async () => {
-    await expect(
-      makeServerStreamRequest({ name: 1234 } as never, async () => {
+    const { error } = await makeServerStreamRequest(
+      { name: 1234 } as never,
+      async () => {
         throw new Error(`Should not get to streamReader`);
-      })
-    ).rejects.toThrow(`name: string expected`);
+      }
+    );
+
+    expect(error?.message).toEqual(`name: string expected`);
   });
 
   test("should propagate read processing errors", async () => {
-    await expect(
-      makeServerStreamRequest(async () => {
-        throw new Error(`Mock Read Processing Error`);
-      })
-    ).rejects.toThrow(`Mock Read Processing Error`);
+    const { error } = await makeServerStreamRequest(async () => {
+      throw new Error(`Mock Read Processing Error`);
+    });
+
+    expect(error?.message).toEqual(`Mock Read Processing Error`);
   });
 
   test("should propagate timeout errors", async () => {
     RESPONSE_DELAY = 1000;
-    await expect(
-      makeServerStreamRequest(
-        {},
-        async () => {
-          throw new Error(`Should not get to streamReader`);
-        },
-        { timeout: 100 }
-      )
-    ).rejects.toThrow(
+    const { error } = await makeServerStreamRequest(
+      {},
+      async () => {
+        throw new Error(`Should not get to streamReader`);
+      },
+      { timeout: 100 }
+    );
+
+    expect(error?.message).toEqual(
       `makeServerStreamRequest for 'customers.Customers.FindCustomers' timed out`
     );
   });
 
   test("should handle service errors", async () => {
     THROW_ERROR_RESPONSE = true;
-    await expect(
-      makeServerStreamRequest(async () => {
-        throw new Error(`Should not get to streamReader`);
-      })
-    ).rejects.toThrow(`13 INTERNAL: Generic Service Error`);
+
+    const { error } = await makeServerStreamRequest(async () => {
+      throw new Error(`Should not get to streamReader`);
+    });
+
+    expect(error?.message).toEqual(`13 INTERNAL: Generic Service Error`);
   });
 
   test("should ignore aborted requests", async () => {
     RESPONSE_DELAY = 1000;
+    const abortController = new AbortController();
+    const request = getServerStreamRequest(
+      {},
+      async () => {
+        throw new Error(`Should not get to streamReader`);
+      },
+      abortController
+    );
+
     return new Promise<void>((resolve, reject) => {
-      const abortController = new AbortController();
-      makeServerStreamRequest(
-        {},
-        async () => {
-          throw new Error(`Should not get to streamReader`);
-        },
-        abortController
-      )
+      request
+        .waitForEnd()
         .then(() => reject(new Error(`Should not have a successful return`)))
         .catch(() => reject(new Error(`Should not reject`)));
 
       setTimeout(() => {
-        activeRequest.on("aborted", () => resolve());
+        request.on("aborted", () => resolve());
         abortController.abort();
       }, 100);
     });
@@ -262,29 +275,20 @@ describe("makeServerStreamRequest", () => {
   test("should propagate aborted error when configured too", async () => {
     RESPONSE_DELAY = 1000;
     getClient().clientSettings.rejectOnAbort = true;
-    return new Promise<void>((resolve, reject) => {
-      const abortController = new AbortController();
-      makeServerStreamRequest(
-        {},
-        async () => {
-          throw new Error(`Should not get to streamReader`);
-        },
-        abortController
-      )
-        .then(() => reject(new Error(`Should not have a successful return`)))
-        .catch((e) => {
-          try {
-            expect(e).toBeInstanceOf(RequestError);
-            expect((e as RequestError).details).toStrictEqual(
-              `Cancelled makeServerStreamRequest for 'customers.Customers.FindCustomers'`
-            );
-            resolve();
-          } catch (matchError) {
-            reject(matchError);
-          }
-        });
+    const abortController = new AbortController();
+    const request = getServerStreamRequest(
+      {},
+      async () => {
+        throw new Error(`Should not get to streamReader`);
+      },
+      abortController
+    );
 
-      setTimeout(() => abortController.abort(), 100);
-    });
+    await wait(100);
+    abortController.abort();
+
+    await expect(request.waitForEnd()).rejects.toThrow(
+      `Cancelled makeServerStreamRequest for 'customers.Customers.FindCustomers'`
+    );
   });
 });

--- a/test/metadata.test.ts
+++ b/test/metadata.test.ts
@@ -150,12 +150,14 @@ describe("metadata", () => {
     });
 
     test("should fail the request if auth token is invalid in metadata", async () => {
-      await expect(
-        makeUnaryRequest(
-          { id: "github" },
-          { metadata: { auth_token: "barbaz" } }
-        )
-      ).rejects.toThrow(`Missing auth_token metadata`);
+      const { error } = await makeUnaryRequest(
+        { id: "github" },
+        { metadata: { auth_token: "barbaz" } }
+      );
+
+      expect(error?.message).toStrictEqual(
+        `13 INTERNAL: Missing auth_token metadata`
+      );
     });
   });
 
@@ -206,15 +208,17 @@ describe("metadata", () => {
     });
 
     test("should fail the request if auth token is invalid in metadata", async () => {
-      await expect(
-        makeClientStreamRequest(
-          async (write) => {
-            await write({ id: "github", name: "Github" });
-            await write({ id: "npm", name: "NPM" });
-          },
-          { metadata: { auth_token: "barbaz" } }
-        )
-      ).rejects.toThrow(`Missing auth_token metadata`);
+      const { error } = await makeClientStreamRequest(
+        async (write) => {
+          await write({ id: "github", name: "Github" });
+          await write({ id: "npm", name: "NPM" });
+        },
+        { metadata: { auth_token: "barbaz" } }
+      );
+
+      expect(error?.message).toStrictEqual(
+        `13 INTERNAL: Missing auth_token metadata`
+      );
     });
   });
 
@@ -260,11 +264,17 @@ describe("metadata", () => {
     });
 
     test("should fail the request if auth token is invalid in metadata", async () => {
-      await expect(
-        makeServerStreamRequest({}, async () => undefined, {
+      const { error } = await makeServerStreamRequest(
+        {},
+        async () => undefined,
+        {
           metadata: { auth_token: "barbaz" },
-        })
-      ).rejects.toThrow(`Missing auth_token metadata`);
+        }
+      );
+
+      expect(error?.message).toStrictEqual(
+        `13 INTERNAL: Missing auth_token metadata`
+      );
     });
   });
 
@@ -322,18 +332,20 @@ describe("metadata", () => {
     });
 
     test("should fail the request if auth token is invalid in metadata", async () => {
-      await expect(
-        makeBidiStreamRequest(
-          async (write) => {
-            await write({ id: "github", name: "Github" });
-            await write({ id: "npm", name: "NPM" });
-          },
-          async () => undefined,
-          {
-            metadata: { auth_token: "barbaz" },
-          }
-        )
-      ).rejects.toThrow(`Missing auth_token metadata`);
+      const { error } = await makeBidiStreamRequest(
+        async (write) => {
+          await write({ id: "github", name: "Github" });
+          await write({ id: "npm", name: "NPM" });
+        },
+        async () => undefined,
+        {
+          metadata: { auth_token: "barbaz" },
+        }
+      );
+
+      expect(error?.message).toStrictEqual(
+        `13 INTERNAL: Missing auth_token metadata`
+      );
     });
   });
 });

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -52,24 +52,21 @@ describe("metadata", () => {
   test("should fail the request if an error is thrown in the middleware", async () => {
     thrownEntity = new Error(`Mock Middleware Error`);
 
-    await expect(makeUnaryRequest({ id: "github" })).rejects.toThrow(
-      `Mock Middleware Error`
-    );
+    const { error } = await makeUnaryRequest({ id: "github" });
+    expect(error?.message).toStrictEqual(`Mock Middleware Error`);
   });
 
   test("should fail the request if a string is thrown in the middleware", async () => {
     thrownEntity = `Mock String Middleware Error`;
 
-    await expect(makeUnaryRequest({ id: "github" })).rejects.toThrow(
-      `Mock String Middleware Error`
-    );
+    const { error } = await makeUnaryRequest({ id: "github" });
+    expect(error?.message).toStrictEqual(`Mock String Middleware Error`);
   });
 
   test("should fail the request anything is thrown in the middleware", async () => {
     thrownEntity = { custom: "Some Custom Thrown Object" };
 
-    await expect(makeUnaryRequest({ id: "github" })).rejects.toThrow(
-      `Unknown Middleware Error: [object Object]`
-    );
+    const { error } = await makeUnaryRequest({ id: "github" });
+    expect(error?.message).toStrictEqual(`Unknown Middleware Error`);
   });
 });

--- a/test/pipe.test.ts
+++ b/test/pipe.test.ts
@@ -1,0 +1,188 @@
+import {
+  sendUnaryData,
+  ServerReadableStream,
+  ServerWritableStream,
+  status,
+} from "@grpc/grpc-js";
+import { EventEmitter, Readable } from "stream";
+import { promisify } from "util";
+import { ProtoClient } from "../src";
+import { MockServiceError } from "./MockServiceError";
+import {
+  Customer,
+  CustomersResponse,
+  FindCustomersRequest,
+  getClient,
+  getServerStreamRequest,
+  makeClientStreamRequest,
+  startServer,
+  wait,
+} from "./utils";
+
+describe("pipe", () => {
+  let client: ProtoClient;
+  let THROW_FIND_ERROR: MockServiceError | undefined;
+
+  beforeEach(async () => {
+    THROW_FIND_ERROR = undefined;
+
+    await startServer({
+      EditCustomer: (
+        call: ServerReadableStream<Customer, CustomersResponse>,
+        callback: sendUnaryData<CustomersResponse>
+      ) => {
+        const customers: Customer[] = [];
+        call.on("data", (row: Customer) => {
+          customers.push(row);
+        });
+
+        call.on("end", () => {
+          callback(null, { customers });
+        });
+      },
+
+      FindCustomers: async (
+        call: ServerWritableStream<FindCustomersRequest, Customer>
+      ) => {
+        if (THROW_FIND_ERROR) {
+          return call.destroy(THROW_FIND_ERROR);
+        }
+
+        const CUSTOMERS: Customer[] = [
+          { id: "github", name: "Github" },
+          { id: "npm", name: "NPM" },
+          { id: "circleci", name: "CircleCI" },
+        ];
+
+        for (const customer of CUSTOMERS) {
+          await promisify(call.write.bind(call))(customer);
+        }
+
+        call.end();
+      },
+    });
+
+    client = getClient();
+  });
+
+  test("should handle readable stream passed instead of writer sandbox", async () => {
+    const { result } = await client.makeRequest<Customer, CustomersResponse>({
+      method: "customers.Customers.EditCustomer",
+      pipeStream: Readable.from([
+        { id: "github", name: "Github" },
+        { id: "npm", name: "NPM" },
+      ]),
+    });
+
+    expect(result).toEqual({
+      customers: [
+        {
+          id: "github",
+          name: "Github",
+        },
+        {
+          id: "npm",
+          name: "NPM",
+        },
+      ],
+    });
+  });
+
+  test("should handle piping another client request", async () => {
+    const readStreamRequest = getServerStreamRequest();
+    const { result } = await makeClientStreamRequest(readStreamRequest);
+    expect(result).toEqual({
+      customers: [
+        { id: "github", name: "Github" },
+        { id: "npm", name: "NPM" },
+        { id: "circleci", name: "CircleCI" },
+      ],
+    });
+  });
+
+  test("should handle piped errors from another client request", async () => {
+    THROW_FIND_ERROR = new MockServiceError(
+      status.INTERNAL,
+      "Mock Find Customers Error"
+    );
+    const readStreamRequest = getServerStreamRequest();
+    const { error, result } = await makeClientStreamRequest(readStreamRequest);
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).toEqual(`13 INTERNAL: Mock Find Customers Error`);
+    expect(result).toBeUndefined();
+  });
+
+  test("should handle piped stream errors", async () => {
+    const stream = new EventEmitter();
+    const request = client.getRequest<Customer, CustomersResponse>({
+      method: "customers.Customers.EditCustomer",
+      pipeStream: stream,
+    });
+
+    request.on("error", () => undefined);
+    stream.on("error", () => undefined);
+
+    await wait();
+    stream.emit("error", new Error("Mock Pipe Error"));
+
+    await request.waitForEnd();
+    expect(request.error?.message).toStrictEqual(`Mock Pipe Error`);
+  });
+
+  test("should handle unknown piped stream errors", async () => {
+    const stream = new EventEmitter();
+    const request = client.getRequest<Customer, CustomersResponse>({
+      method: "customers.Customers.EditCustomer",
+      pipeStream: stream,
+    });
+
+    await wait();
+    stream.emit("error", "Mock Pipe String Error");
+
+    await request.waitForEnd();
+    expect(request.error?.message).toStrictEqual(`Pipe stream error`);
+  });
+
+  test("should ignore extra events emitted from piped stream once request is completed", async () => {
+    const stream = new EventEmitter();
+    const request = client.getRequest<Customer, CustomersResponse>({
+      method: "customers.Customers.EditCustomer",
+      pipeStream: stream,
+    });
+
+    await wait();
+    stream.emit("data", { id: "github", name: "Github" });
+    await wait();
+    stream.emit("end");
+
+    await request.waitForEnd();
+    expect(request.error).toBeUndefined();
+    expect(request.result).toEqual({
+      customers: [{ id: "github", name: "Github" }],
+    });
+
+    // Emitting more data should be ignored
+    stream.emit("data", { id: "npm", name: "NPM" });
+    await request.waitForEnd();
+    expect(request.error).toBeUndefined();
+    expect(request.result).toEqual({
+      customers: [{ id: "github", name: "Github" }],
+    });
+
+    // Emitting an error should be ignored
+    stream.emit("error", new Error(`Mock Pipe Error`));
+    await request.waitForEnd();
+    expect(request.error).toBeUndefined();
+    expect(request.result).toEqual({
+      customers: [{ id: "github", name: "Github" }],
+    });
+
+    // Emitting end event again should be ignored
+    stream.emit("end");
+    await request.waitForEnd();
+    expect(request.error).toBeUndefined();
+    expect(request.result).toEqual({
+      customers: [{ id: "github", name: "Github" }],
+    });
+  });
+});

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -19,12 +19,12 @@ describe("util", () => {
       },
     });
 
-    request = new ProtoRequest<unknown, unknown>(
+    request = new ProtoRequest<unknown, unknown>({
       client,
-      "customers.Customers.GetCustomer",
-      RequestMethodType.UnaryRequest,
-      undefined
-    );
+      method: "customers.Customers.GetCustomer",
+      requestMethodType: RequestMethodType.UnaryRequest,
+      blockAutoStart: true,
+    });
   });
 
   describe("generateEndpointMatcher", () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -12,6 +12,7 @@ import {
   StreamWriterSandbox,
 } from "../src";
 import { promisify } from "util";
+import { EventEmitter, Readable } from "stream";
 
 let activeServers: Server[] = [];
 let activeClient: ProtoClient | undefined;
@@ -60,12 +61,15 @@ export const makeUnaryRequest = (
   );
 
 export const makeClientStreamRequest = (
-  writerSandbox: StreamWriterSandbox<Customer, CustomersResponse>,
+  writerSandbox?:
+    | StreamWriterSandbox<Customer, CustomersResponse>
+    | Readable
+    | EventEmitter,
   requestOptions?: RequestOptions | AbortController
 ) =>
   getClient().makeClientStreamRequest<Customer, CustomersResponse>(
     "customers.Customers.EditCustomer",
-    writerSandbox,
+    writerSandbox as StreamWriterSandbox<Customer, CustomersResponse>,
     requestOptions as RequestOptions
   );
 
@@ -82,13 +86,66 @@ export const makeServerStreamRequest = (
   );
 
 export const makeBidiStreamRequest = (
-  writerSandbox: StreamWriterSandbox<Customer, Customer>,
+  writerSandbox:
+    | StreamWriterSandbox<Customer, Customer>
+    | Readable
+    | EventEmitter,
   streamReader: StreamReader<Customer, Customer>,
   requestOptions?: RequestOptions | AbortController
 ) =>
   getClient().makeBidiStreamRequest<Customer, Customer>(
     "customers.Customers.CreateCustomers",
-    writerSandbox,
+    writerSandbox as StreamWriterSandbox<Customer, Customer>,
+    streamReader,
+    requestOptions as RequestOptions
+  );
+
+export const getUnaryRequest = (
+  data?: GetCustomerRequest,
+  requestOptions?: RequestOptions | AbortController
+) =>
+  getClient().getUnaryRequest<GetCustomerRequest, Customer>(
+    "customers.Customers.GetCustomer",
+    data as GetCustomerRequest,
+    requestOptions as RequestOptions
+  );
+
+export const getClientStreamRequest = (
+  writerSandbox?:
+    | StreamWriterSandbox<Customer, CustomersResponse>
+    | Readable
+    | EventEmitter,
+  requestOptions?: RequestOptions | AbortController
+) =>
+  getClient().getClientStreamRequest<Customer, CustomersResponse>(
+    "customers.Customers.EditCustomer",
+    writerSandbox as StreamWriterSandbox<Customer, CustomersResponse>,
+    requestOptions as RequestOptions
+  );
+
+export const getServerStreamRequest = (
+  data?: FindCustomersRequest | StreamReader<FindCustomersRequest, Customer>,
+  streamReader?: StreamReader<FindCustomersRequest, Customer>,
+  requestOptions?: RequestOptions | AbortController
+) =>
+  getClient().getServerStreamRequest<FindCustomersRequest, Customer>(
+    "customers.Customers.FindCustomers",
+    data as FindCustomersRequest,
+    streamReader as StreamReader<FindCustomersRequest, Customer>,
+    requestOptions as RequestOptions
+  );
+
+export const getBidiStreamRequest = (
+  writerSandbox:
+    | StreamWriterSandbox<Customer, Customer>
+    | Readable
+    | EventEmitter,
+  streamReader: StreamReader<Customer, Customer>,
+  requestOptions?: RequestOptions | AbortController
+) =>
+  getClient().getBidiStreamRequest<Customer, Customer>(
+    "customers.Customers.CreateCustomers",
+    writerSandbox as StreamWriterSandbox<Customer, Customer>,
     streamReader,
     requestOptions as RequestOptions
   );


### PR DESCRIPTION
- Refactored ProtoRequest to support piping of readable streams into client writable streams
- ProtoRequest instances can now be piped into other proto requests
- Generic requests can now be made through makeRequest, without specifying method type (will be inferred from the proto definition)
- Added `rejectOnError` configuration, defaulting to false. Going forward, any server/processing errors will return rather than reject by default
- Added data event to ProtoRequest, which will be triggered on every response from the server
- Added error event to ProtoRequest, which will emit any resolved errors during the request flow
- Filling out JSDoc strings for all methods