### PR TITLE
Using deadline for timeouts, removing retryOnClientTimeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ Every request is wrapped in a retry function, allowing for fully customized hand
 
 - `retryCount`: Number of times to retry request. Defaults to none
 - `status`: Status code(s) request is allowed to retry on. Uses default list of status codes if not defined
-- `retryOnClientTimeout`: Indicates if retries should be allowed when the client times out. Defaults to true.
 
 ## Static Code Generation
 

--- a/src/RequestError.ts
+++ b/src/RequestError.ts
@@ -36,8 +36,6 @@ export class RequestError extends Error implements ServiceError {
     if (!details) {
       if (code === status.CANCELLED) {
         details = `Cancelled ${request.requestMethodType} for '${request.method}'`;
-      } else if (code === status.DEADLINE_EXCEEDED) {
-        details = `${request.requestMethodType} for '${request.method}' timed out`;
       } else {
         details = `${code} ${status[code]}: ${request.requestMethodType} for '${request.method}'`;
       }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -181,11 +181,6 @@ export interface RequestRetryOptions {
    * Status codes request is allowed to retry on
    */
   status?: status | status[];
-
-  /**
-   * Indicates if retry should occur after internal client timeout. Defaults to true
-   */
-  retryOnClientTimeout?: boolean;
 }
 
 /**

--- a/test/makeClientStreamRequest.test.ts
+++ b/test/makeClientStreamRequest.test.ts
@@ -227,9 +227,7 @@ describe("makeClientStreamRequest", () => {
       { timeout: 100 }
     );
 
-    expect(error?.message).toEqual(
-      `makeClientStreamRequest for 'customers.Customers.EditCustomer' timed out`
-    );
+    expect(error?.message).toEqual(`4 DEADLINE_EXCEEDED: Deadline exceeded`);
   });
 
   test("should handle service errors", async () => {

--- a/test/makeServerStreamRequest.test.ts
+++ b/test/makeServerStreamRequest.test.ts
@@ -233,9 +233,7 @@ describe("makeServerStreamRequest", () => {
       { timeout: 100 }
     );
 
-    expect(error?.message).toEqual(
-      `makeServerStreamRequest for 'customers.Customers.FindCustomers' timed out`
-    );
+    expect(error?.message).toEqual(`4 DEADLINE_EXCEEDED: Deadline exceeded`);
   });
 
   test("should handle service errors", async () => {

--- a/test/makeUnaryRequest.test.ts
+++ b/test/makeUnaryRequest.test.ts
@@ -115,7 +115,7 @@ describe("makeUnaryRequest", () => {
     );
 
     expect(error?.message).toStrictEqual(
-      `makeUnaryRequest for 'customers.Customers.GetCustomer' timed out`
+      `4 DEADLINE_EXCEEDED: Deadline exceeded`
     );
   });
 

--- a/test/pipe.test.ts
+++ b/test/pipe.test.ts
@@ -142,47 +142,4 @@ describe("pipe", () => {
     await request.waitForEnd();
     expect(request.error?.message).toStrictEqual(`Pipe stream error`);
   });
-
-  test("should ignore extra events emitted from piped stream once request is completed", async () => {
-    const stream = new EventEmitter();
-    const request = client.getRequest<Customer, CustomersResponse>({
-      method: "customers.Customers.EditCustomer",
-      pipeStream: stream,
-    });
-
-    await wait();
-    stream.emit("data", { id: "github", name: "Github" });
-    await wait();
-    stream.emit("end");
-
-    await request.waitForEnd();
-    expect(request.error).toBeUndefined();
-    expect(request.result).toEqual({
-      customers: [{ id: "github", name: "Github" }],
-    });
-
-    // Emitting more data should be ignored
-    stream.emit("data", { id: "npm", name: "NPM" });
-    await request.waitForEnd();
-    expect(request.error).toBeUndefined();
-    expect(request.result).toEqual({
-      customers: [{ id: "github", name: "Github" }],
-    });
-
-    // Emitting an error should be ignored
-    stream.emit("error", new Error(`Mock Pipe Error`));
-    await request.waitForEnd();
-    expect(request.error).toBeUndefined();
-    expect(request.result).toEqual({
-      customers: [{ id: "github", name: "Github" }],
-    });
-
-    // Emitting end event again should be ignored
-    stream.emit("end");
-    await request.waitForEnd();
-    expect(request.error).toBeUndefined();
-    expect(request.result).toEqual({
-      customers: [{ id: "github", name: "Github" }],
-    });
-  });
 });

--- a/test/retryOptions.test.ts
+++ b/test/retryOptions.test.ts
@@ -50,7 +50,7 @@ describe("retryOptions", () => {
     );
 
     expect(request.error?.message).toEqual(
-      `makeUnaryRequest for 'customers.Customers.GetCustomer' timed out`
+      `4 DEADLINE_EXCEEDED: Deadline exceeded`
     );
     expect(request.responseErrors).toEqual([
       expect.objectContaining({ code: status.DEADLINE_EXCEEDED }),
@@ -138,24 +138,5 @@ describe("retryOptions", () => {
       expect.objectContaining({ code: status.INTERNAL }),
     ]);
     expect(request.error).toStrictEqual(request.responseErrors[2]);
-  });
-
-  test("should not retry when configured to error out on timeouts", async () => {
-    RESPONSE_DELAY = 2000;
-    const request = await makeUnaryRequest(
-      { id: "github" },
-      {
-        timeout: 100,
-        retryOptions: { retryCount: 3, retryOnClientTimeout: false },
-      }
-    );
-
-    expect(request.error?.message).toEqual(
-      `makeUnaryRequest for 'customers.Customers.GetCustomer' timed out`
-    );
-    expect(request.responseErrors).toEqual([
-      expect.objectContaining({ code: status.DEADLINE_EXCEEDED }),
-    ]);
-    expect(request.error).toStrictEqual(request.responseErrors[0]);
   });
 });

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -78,9 +78,6 @@ describe("util", () => {
       expect(normalizeRetryOptions(true)).toStrictEqual({ retryCount: 1 });
       expect(normalizeRetryOptions(false)).toStrictEqual({ retryCount: 0 });
       expect(normalizeRetryOptions(15)).toStrictEqual({ retryCount: 15 });
-      expect(
-        normalizeRetryOptions({ retryCount: 3, retryOnClientTimeout: true })
-      ).toStrictEqual({ retryCount: 3, retryOnClientTimeout: true });
     });
   });
 });


### PR DESCRIPTION
- retryOnClientTimeout removed in favor of grpc deadline mechanism (deadline is retried by default in status codes)
- Removing event listeners from the call stream once it has ended